### PR TITLE
BUGFIX: Convert file.contents to a string

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ var validatePlugin = function (params) {
 
     var sleepValue = (lastCall ? ((Date.now() - lastCall) < sleep ? sleep : 0) : 0);
 
-    var p = extend({ text: file.contents }, params);
+    var p = extend({ text: String(file.contents) }, params);
     setTimeout(function() {
       validator.validate(p, function (err, data) {
         lastCall = Date.now();


### PR DESCRIPTION
In using `gulp-w3c-css` I was getting `504` responses from the API because one of the string params were not supported. Converting `file.contents` solved the issue for me.
